### PR TITLE
improve assignment of mockMarker to avoid typescript compilation issues

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,6 +1,6 @@
 export { MockRepository } from "./src/mockRepository/mockRepository";
 export { MockFactory } from "./src/mockFactory/mockFactory";
 export { MockMarker } from "./src/mockMarker/mockMarker";
+export { MockMethod } from "./src/mockMethod/mockMethod";
 export { On, mockedMethod, Extension, AutoMockExtensionHandler } from "./src/framework/framework";
-export { MockMethod } from "./src/mock/mockMethod";
 export { createMock } from "./src/transformer/create-mock";

--- a/package.json
+++ b/package.json
@@ -18,11 +18,11 @@
     "auto"
   ],
   "files": [
-    "src/framework/*.d.ts",
-    "src/mock/*.d.ts",
-    "src/mockFactory/*.d.ts",
-    "src/mockRepository/*.d.ts",
-    "src/mockMarker/*.d.ts",
+    "src/framework/framework.d.ts",
+    "src/mockMethod/mockMethod.d.ts",
+    "src/mockFactory/mockFactory.d.ts",
+    "src/mockRepository/mockRepository.ts",
+    "src/mockMarker/mockMarker.d.ts",
     "src/transformer/transformer.d.ts",
     "src/transformer/create-mock.ts",
     "index.d.ts",

--- a/src/framework/framework.ts
+++ b/src/framework/framework.ts
@@ -1,5 +1,5 @@
 import { MockMarker } from "../mockMarker/mockMarker";
-import { MockMethod } from "../mock/mockMethod";
+import { MockMethod } from "../mockMethod/mockMethod";
 
 function Mock<U extends object>(mock: U): AutoMockExtensionHandler<U> {
 	const symbols: Symbol[] = Object.getOwnPropertySymbols(mock);

--- a/src/mock/mockMethod.d.ts
+++ b/src/mock/mockMethod.d.ts
@@ -1,3 +1,0 @@
-type ReturnType = Function;
-
-export declare interface MockMethod<TR> extends ReturnType {}

--- a/src/transformer/descriptor/method/method.ts
+++ b/src/transformer/descriptor/method/method.ts
@@ -23,9 +23,3 @@ export function GetMethodDescriptor(propertyName: ts.PropertyName, returnValue: 
     const parenthesizedExpression = ts.createParen(functionExpression);
     return ts.createCall(parenthesizedExpression, [], []);
 }
-
-export function GetEmptyMethodDescriptor() {
-	const property = ts.createIdentifier("");
-	const returnValue = ts.createIdentifier("");
-	return GetMethodDescriptor(property, returnValue);
-}

--- a/src/transformer/descriptor/mock/mockCall.ts
+++ b/src/transformer/descriptor/mock/mockCall.ts
@@ -1,26 +1,54 @@
 import * as ts from 'typescript';
 import { TypescriptHelper } from "../helper/helper";
-import { GetMockMarkerProperty } from "./mockMarker";
+import { GetMockMarkerProperty, Property } from "./mockMarker";
 
 export function GetMockCall(declarations: Array<ts.VariableDeclaration>, properties: Array<ts.AccessorDeclaration>): ts.CallExpression {
-    const statements = [];
+    const uniqueNameVariable = "__tsAutoMockObjectReturnValue";
+    const identifierUniqueNameVariable = ts.createIdentifier(uniqueNameVariable);
+    
+    const listOfVariables = GetListOfVariables(declarations, identifierUniqueNameVariable);
 
-    if (declarations.length) {
-        const variableStatement = ts.createVariableStatement([], declarations);
-
-        statements.push(variableStatement);
-    }
-
-    const mockMarkerProperty = GetMockMarkerProperty();
-    const propertiesToAssign = [...properties, mockMarkerProperty];
-    const returnStatement = ts.createReturn(
-        ts.createObjectLiteral(propertiesToAssign, true)
-    );
-
-    statements.push(returnStatement);
+    const mockMarkerPropertyAssigned = GetMockMarkerPropertyAssignedTo(identifierUniqueNameVariable);
+    
+    const objectToReturn = GetObjectWithPropertiesToReturn(properties, identifierUniqueNameVariable);
+    
+    const returnStatement = ts.createReturn(identifierUniqueNameVariable);
+    
+    const statements = [
+        listOfVariables,
+        objectToReturn,
+        mockMarkerPropertyAssigned,
+        returnStatement
+    ];
 
     const arrowFunctionBlock = ts.createBlock(statements);
     const arrowFunction = TypescriptHelper.createArrowFunction(arrowFunctionBlock);
     const IFFEFunction = ts.createParen(arrowFunction);
     return ts.createCall(IFFEFunction, [], []);
+}
+
+function GetListOfVariables(declarations: Array<ts.VariableDeclaration>, identifierUniqueNameVariable: ts.Identifier): ts.VariableStatement {
+    const variableDeclarationUnique = ts.createVariableDeclaration(identifierUniqueNameVariable, undefined, ts.createObjectLiteral());
+    const variables =  declarations.length ? [...declarations, variableDeclarationUnique]: [variableDeclarationUnique];
+    return ts.createVariableStatement([], variables);
+}
+
+function GetObjectWithPropertiesToReturn(properties: Array<ts.AccessorDeclaration>, identifierUniqueNameVariable: ts.Identifier): ts.ExpressionStatement {
+    const returnObject = ts.createObjectLiteral(properties, true);
+    const binaryExpression = ts.createBinary(identifierUniqueNameVariable, ts.SyntaxKind.EqualsToken, returnObject);
+    return ts.createExpressionStatement(binaryExpression);
+}
+
+function GetMockMarkerPropertyAssignedTo(identifier: ts.Identifier): ts.ExpressionStatement {
+    const mockMarkerProperty: Property = GetMockMarkerProperty();
+    
+    const argumentsDefineProperty = [
+        identifier,
+        mockMarkerProperty.name,
+        ts.createObjectLiteral([ts.createPropertyAssignment("value", mockMarkerProperty.value)])
+    ];
+    
+    const objectDefineProperty = ts.createPropertyAccess(ts.createIdentifier("Object"), ts.createIdentifier("defineProperty"));
+    const objectDefinePropertyCall = ts.createCall(objectDefineProperty, [], argumentsDefineProperty);
+    return ts.createExpressionStatement(objectDefinePropertyCall);
 }

--- a/src/transformer/descriptor/mock/mockMarker.ts
+++ b/src/transformer/descriptor/mock/mockMarker.ts
@@ -1,7 +1,12 @@
-import * as ts from "typescript";
+import * as ts from 'typescript';
 import { MockDefiner } from "../../mockDefiner/mockDefiner";
 
-export function GetMockMarkerProperty() {
+export interface Property {
+	name: ts.Expression,
+	value: ts.Expression
+}
+
+export function GetMockMarkerProperty(): Property {
 	const propertyAccessExpression = ts.createPropertyAccess(
 		ts.createPropertyAccess(
 			ts.createPropertyAccess(
@@ -12,6 +17,9 @@ export function GetMockMarkerProperty() {
 		ts.createIdentifier("get"));
 	
 	const mockMarkerCall = ts.createCall(propertyAccessExpression, [], []);
-	const computedPropertyName = ts.createComputedPropertyName(mockMarkerCall);
-	return ts.createPropertyAssignment(computedPropertyName, ts.createLiteral(true));
+	
+	return {
+		name: mockMarkerCall,
+		value: ts.createLiteral(true)
+	};
 }

--- a/src/transformer/descriptor/tsLibs/typescriptLibsTypeAdapter.ts
+++ b/src/transformer/descriptor/tsLibs/typescriptLibsTypeAdapter.ts
@@ -26,7 +26,7 @@ export function TypescriptLibsTypeAdapter(node): ts.Node {
         case(TypescriptLibsTypes.Promise):
             const parameter = node.typeParameters[0];
             const type = typeChecker.getTypeAtLocation(parameter);
-
+	
             const promiseResolveType = TypeReferenceCache.instance.get(type);
             const promiseAccess = ts.createPropertyAccess(ts.createIdentifier("Promise"), ts.createIdentifier("resolve"));
             

--- a/src/transformer/descriptor/typeParameter/typeParameter.ts
+++ b/src/transformer/descriptor/typeParameter/typeParameter.ts
@@ -6,7 +6,7 @@ import { GetDescriptor } from '../descriptor';
 export function GetTypeParameterDescriptor(node: ts.TypeParameterDeclaration): ts.Expression {
     const typeChecker = TypeChecker();
     const type = typeChecker.getTypeAtLocation(node);
-
+    
     const cacheType = TypeReferenceCache.instance.get(type);
     if (!cacheType) {
         if (node.default) {

--- a/src/transformer/descriptor/typeReference/typeReference.ts
+++ b/src/transformer/descriptor/typeReference/typeReference.ts
@@ -1,6 +1,5 @@
 import * as ts from 'typescript';
 import { GetDescriptor } from "../descriptor";
-import { TypeChecker } from "../../typeChecker/typeChecker";
 import { TypeReferenceCache } from "./cache";
 import { TypescriptHelper } from '../helper/helper';
 


### PR DESCRIPTION
Basically I had an issue when adding a computer property 

``` ts
return {
 [Symbol("__mockMarker"]): true
}

``` 

for some reason typescript compiles it to 

```ts
var _a = {}

_a[Symbol("__mockMarker")] = true;

return _a;
```

the _a variable was clashing to the name of the import

Instead I've manually created the object with a unique name __tsAutoMockObjectReturnValue

