### PR TITLE
#18 remove function type as reusable type

### DIFF
--- a/src/transformer/typeValidator/typeValidator.ts
+++ b/src/transformer/typeValidator/typeValidator.ts
@@ -5,8 +5,7 @@ const reusableTypes = [
     ts.SyntaxKind.ClassDeclaration,
     ts.SyntaxKind.InterfaceDeclaration,
     ts.SyntaxKind.TypeLiteral,
-    ts.SyntaxKind.MappedType,
-    ts.SyntaxKind.FunctionType
+    ts.SyntaxKind.MappedType
 ];
 
 export function isTypeReusable(node: ts.Node): boolean {

--- a/test/framework/functions.test.ts
+++ b/test/framework/functions.test.ts
@@ -22,4 +22,16 @@ describe('functions', () => {
 			On(mock).get(method(x => x.apply))
 		}).toThrow();
 	});
+
+	it('should create different factories for different functions mock', () => {
+		interface Mock {
+			woooow: Function;
+			duuuuuuu: Function;
+			great(): string;
+		}
+		const mock: Mock = createMock<Mock>();
+
+		expect((mock.woooow as jasmine.Spy).and.identity).toBe('woooow');
+		expect((mock.duuuuuuu as jasmine.Spy).and.identity).toBe('duuuuuuu');
+	});
 });

--- a/test/framework/functions.test.ts
+++ b/test/framework/functions.test.ts
@@ -25,13 +25,12 @@ describe('functions', () => {
 
 	it('should create different factories for different functions mock', () => {
 		interface Mock {
-			woooow: Function;
-			duuuuuuu: Function;
-			great(): string;
+			first: Function;
+			second: Function;
 		}
 		const mock: Mock = createMock<Mock>();
 
-		expect((mock.woooow as jasmine.Spy).and.identity).toBe('woooow');
-		expect((mock.duuuuuuu as jasmine.Spy).and.identity).toBe('duuuuuuu');
+		expect((mock.first as jasmine.Spy).and.identity).toBe('first');
+		expect((mock.second as jasmine.Spy).and.identity).toBe('second');
 	});
 });


### PR DESCRIPTION
Removing the function type as reusable type the method is always properly mocked using the mock factory. Before it was creating a mock in the repository for the function type meaning that every function type were reusing the same MockFactory usage. In the jasmine case this means having only one jasmine.createSpy using always the same name.