### PR TITLE
fix(core): use path.relative to check if two urls are the same

### DIFF
--- a/src/transformer/matcher/matcher.ts
+++ b/src/transformer/matcher/matcher.ts
@@ -23,13 +23,13 @@ export function isFromTsAutoMock(signature: ts.Signature): boolean {
     const createMockListTs: string = path.join(__dirname, `../create-mock-list.d.ts`);
     const fileName: string = signature.declaration.getSourceFile().fileName;
 
-    const isCreateMockUrl: boolean = fileName.indexOf('create-mock.d.ts') > -1 && path.relative(fileName, createMockTs) === '';
-    if (!isCreateMockUrl) {
+    const isCreateMockUrl: boolean = path.relative(fileName, createMockTs) === '';
+    if (fileName.indexOf('create-mock.d.ts') > -1 && isCreateMockUrl) {
         TransformerLogger().unexpectedCreateMock(fileName, createMockTs);
     }
 
-    const isCreateMockListUrl: boolean = fileName.indexOf('create-mock-list.d.ts') > -1 && path.relative(fileName, createMockListTs) === '';
-    if (!isCreateMockListUrl) {
+    const isCreateMockListUrl: boolean = path.relative(fileName, createMockListTs) === '';
+    if (fileName.indexOf('create-mock-list.d.ts') > -1 && !isCreateMockListUrl) {
         TransformerLogger().unexpectedCreateMock(fileName, createMockListTs);
     }
 

--- a/src/transformer/matcher/matcher.ts
+++ b/src/transformer/matcher/matcher.ts
@@ -23,15 +23,17 @@ export function isFromTsAutoMock(signature: ts.Signature): boolean {
     const createMockListTs: string = path.join(__dirname, `../create-mock-list.d.ts`);
     const fileName: string = signature.declaration.getSourceFile().fileName;
 
-    if (fileName.indexOf('create-mock.d.ts') > -1 && fileName !== createMockTs) {
+    const isCreateMockUrl: boolean = fileName.indexOf('create-mock.d.ts') > -1 && path.relative(fileName, createMockTs) === '';
+    if (!isCreateMockUrl) {
         TransformerLogger().unexpectedCreateMock(fileName, createMockTs);
     }
 
-    if (fileName.indexOf('create-mock-list.d.ts') > -1 && fileName !== createMockListTs) {
+    const isCreateMockListUrl: boolean = fileName.indexOf('create-mock-list.d.ts') > -1 && path.relative(fileName, createMockListTs) === '';
+    if (!isCreateMockListUrl) {
         TransformerLogger().unexpectedCreateMock(fileName, createMockListTs);
     }
 
-    return fileName === createMockTs || fileName === createMockListTs;
+    return isCreateMockUrl || isCreateMockListUrl;
 }
 
 function isDeclarationDefined(signature: ts.Signature): boolean {


### PR DESCRIPTION
use path.relative to check if two urls are the same to avoid differences between unix and windows path styles