### PR TITLE
add support for this in intersections

### DIFF
--- a/src/transformer/descriptor/class/classDeclaration.ts
+++ b/src/transformer/descriptor/class/classDeclaration.ts
@@ -3,7 +3,5 @@ import { Scope } from '../../scope/scope';
 import { GetProperties } from '../properties/properties';
 
 export function GetClassDeclarationDescriptor(node: ts.ClassDeclaration, scope: Scope): ts.Expression {
-    scope.declarationNode = node;
-
     return GetProperties(node, scope);
 }

--- a/src/transformer/descriptor/descriptor.ts
+++ b/src/transformer/descriptor/descriptor.ts
@@ -55,7 +55,7 @@ export function GetDescriptor(node: ts.Node, scope: Scope): ts.Expression {
         case ts.SyntaxKind.Identifier:
             return GetIdentifierDescriptor(node as ts.Identifier, scope);
         case ts.SyntaxKind.ThisType:
-            return GetMockFactoryCallForThis(scope.declarationNode);
+            return GetMockFactoryCallForThis(scope.currentMockKey);
         case ts.SyntaxKind.ImportSpecifier:
             return GetImportDescriptor(node as ts.ImportSpecifier, scope);
         case ts.SyntaxKind.TypeParameter:

--- a/src/transformer/descriptor/interface/interfaceDeclaration.ts
+++ b/src/transformer/descriptor/interface/interfaceDeclaration.ts
@@ -3,7 +3,5 @@ import { Scope } from '../../scope/scope';
 import { GetProperties } from '../properties/properties';
 
 export function GetInterfaceDeclarationDescriptor(node: ts.InterfaceDeclaration, scope: Scope): ts.Expression {
-    scope.declarationNode = node;
-
     return GetProperties(node, scope);
 }

--- a/src/transformer/descriptor/typeLiteral/typeLiteral.ts
+++ b/src/transformer/descriptor/typeLiteral/typeLiteral.ts
@@ -1,14 +1,7 @@
 import * as ts from 'typescript';
 import { Scope } from '../../scope/scope';
-import { TypeChecker } from '../../typeChecker/typeChecker';
-import { GetMockPropertiesFromSymbol } from '../mock/mockProperties';
+import { GetProperties } from '../properties/properties';
 
 export function GetTypeLiteralDescriptor(node: ts.TypeLiteralNode, scope: Scope): ts.Expression {
-  const typeChecker: ts.TypeChecker = TypeChecker();
-  const type: ts.Type = typeChecker.getTypeAtLocation(node);
-
-  const properties: ts.Symbol[] = typeChecker.getPropertiesOfType(type);
-  const signatures: ReadonlyArray<ts.Signature> = type.getCallSignatures();
-
-  return GetMockPropertiesFromSymbol(properties, signatures, scope);
+  return GetProperties(node, scope);
 }

--- a/src/transformer/mockDefiner/mockDefiner.ts
+++ b/src/transformer/mockDefiner/mockDefiner.ts
@@ -84,23 +84,19 @@ export class MockDefiner {
     }
 
     public getMockFactory(declaration: ts.Declaration): ts.Expression {
-        this.setTsAutoMockImportIdentifier();
-
         const key: string = this._getMockFactoryId(declaration);
 
-        return this._getCallGetFactory(key);
+        return this.getMockFactoryByKey(key);
+    }
+
+    public getMockFactoryIntersection(declarations: ts.Declaration[], type: ts.IntersectionTypeNode): ts.Expression {
+        const key: string = this._getMockFactoryIdForIntersections(declarations, type);
+
+        return this.getMockFactoryByKey(key);
     }
 
     public getMockFactoryByKey(key: string): ts.Expression {
         this.setTsAutoMockImportIdentifier();
-
-        return this._getCallGetFactory(key);
-    }
-
-    public getMockFactoryIntersection(declarations: ts.Declaration[], type: ts.IntersectionTypeNode): ts.Expression {
-        this.setTsAutoMockImportIdentifier();
-
-        const key: string = this._getMockFactoryIdForIntersections(declarations, type);
 
         return this._getCallGetFactory(key);
     }

--- a/src/transformer/mockDefiner/mockDefiner.ts
+++ b/src/transformer/mockDefiner/mockDefiner.ts
@@ -91,6 +91,12 @@ export class MockDefiner {
         return this._getCallGetFactory(key);
     }
 
+    public getMockFactoryByKey(key: string): ts.Expression {
+        this.setTsAutoMockImportIdentifier();
+
+        return this._getCallGetFactory(key);
+    }
+
     public getMockFactoryIntersection(declarations: ts.Declaration[], type: ts.IntersectionTypeNode): ts.Expression {
         this.setTsAutoMockImportIdentifier();
 
@@ -144,7 +150,7 @@ export class MockDefiner {
 
         this._factoryRegistrationsPerFile[thisFileName] = this._factoryRegistrationsPerFile[thisFileName] || [];
 
-        const descriptor: ts.Expression = GetDescriptor(declaration, new Scope());
+        const descriptor: ts.Expression = GetDescriptor(declaration, new Scope(key));
 
         const mockGenericParameter: ts.ParameterDeclaration = this._getMockGenericParameter();
 
@@ -171,7 +177,7 @@ export class MockDefiner {
 
         this._factoryIntersectionsRegistrationsPerFile[thisFileName] = this._factoryIntersectionsRegistrationsPerFile[thisFileName] || [];
 
-        const descriptor: ts.Expression = GetProperties(intersectionTypeNode, new Scope());
+        const descriptor: ts.Expression = GetProperties(intersectionTypeNode, new Scope(key));
 
         const mockGenericParameter: ts.ParameterDeclaration = this._getMockGenericParameter();
 

--- a/src/transformer/mockFactoryCall/mockFactoryCall.ts
+++ b/src/transformer/mockFactoryCall/mockFactoryCall.ts
@@ -57,8 +57,8 @@ export function GetMockFactoryCallIntersection(intersection: ts.IntersectionType
     );
 }
 
-export function GetMockFactoryCallForThis(declaration: ts.Declaration): ts.Expression {
-    const mockFactoryCall: ts.Expression = MockDefiner.instance.getMockFactory(declaration);
+export function GetMockFactoryCallForThis(mockKey: string): ts.Expression {
+    const mockFactoryCall: ts.Expression = MockDefiner.instance.getMockFactoryByKey(mockKey);
 
     return ts.createCall(
         mockFactoryCall,

--- a/src/transformer/scope/scope.ts
+++ b/src/transformer/scope/scope.ts
@@ -2,13 +2,13 @@ import * as ts from 'typescript';
 
 export type InterfaceOrClassDeclaration = ts.InterfaceDeclaration | ts.ClassDeclaration;
 export class Scope {
-    private _declarationNode: InterfaceOrClassDeclaration;
-
-    set declarationNode(node: InterfaceOrClassDeclaration) {
-        this._declarationNode = node;
+    constructor(currentMockKey: string) {
+        this._currentMockKey = currentMockKey;
     }
 
-    get declarationNode(): InterfaceOrClassDeclaration {
-        return this._declarationNode;
+    private readonly _currentMockKey: string;
+
+    get currentMockKey(): string {
+        return this._currentMockKey;
     }
 }

--- a/src/transformer/scope/scope.ts
+++ b/src/transformer/scope/scope.ts
@@ -2,7 +2,7 @@ import * as ts from 'typescript';
 
 export type InterfaceOrClassDeclaration = ts.InterfaceDeclaration | ts.ClassDeclaration;
 export class Scope {
-    constructor(currentMockKey: string) {
+    constructor(currentMockKey?: string) {
         this._currentMockKey = currentMockKey;
     }
 

--- a/test/transformer/descriptor/this/this.test.ts
+++ b/test/transformer/descriptor/this/this.test.ts
@@ -161,4 +161,25 @@ describe('This', () => {
             expect(properties.getThisAfter.getThisBefore.getThisAfter.typeLiteral.a).toBe('');
         });
     });
+
+    describe('for intersections', () => {
+        interface A {
+            intersection: A & B;
+            mySelfA: this;
+            a: string;
+        }
+
+        interface B {
+            mySelfB: this;
+            b: number;
+        }
+
+        it('should be able to reference to itself', () => {
+            const properties: A = createMock<A>();
+            expect(properties.mySelfA.a).toBe('');
+            expect(properties.a).toBe('');
+            expect(properties.intersection.mySelfB.b).toBe(0);
+            expect(properties.intersection.mySelfB.a).toBe('');
+        });
+    });
 });


### PR DESCRIPTION
Hello, After yesterday intersection feature I've found an interesting bug related to "this" in intersections.

We are currently solving the "this" problem storing the Declaration everytime we find a potential Mock.

The problem with this approach is that Intersection is not supported correctly because they are a combination of Declaration.
To follow the same design I would have to store not just A declaration, but the mock declarations that could be a list.

I've realized that we don't need to store a Declaration, we can just store the mock key and everytime we find "this" we can reuse that key.

Let me know what you think :).

This PR also refactor the typeLiteral to use the same method as InterfaceDeclartion and ClassDeclaration that I've introdocued with Intersection feature.

